### PR TITLE
swapping ruff hard-pin for soft-requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ line-length = 79
 
 [tool.ruff]
 line-length = 79
-required-version = "==0.11.0"
+required-version = ">=0.11.0"
 force-exclude = true
 extend-exclude = [
   "notebooks/ami_exploration.ipynb",


### PR DESCRIPTION
This has been making a super annoying error pop up in the corner of my VScode for far too long now.